### PR TITLE
Dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit"]
+        luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit-openresty"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run lints and tests
 
 on: [push, pull_request]
 
@@ -22,7 +22,10 @@ jobs:
     - uses: leafo/gh-actions-luarocks@v4
 
     - name: Install dependencies
-      run: luarocks install busted
+      run: luarocks install luacheck busted
+
+    - name: Run lints
+      run: make lint
 
     - name: Run tests
       run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,11 @@ jobs:
 
     - uses: leafo/gh-actions-luarocks@v4
 
-    - name: Install dependencies
-      run: luarocks install luacheck busted
+    - name: Install luacheck
+      run: luarocks install luacheck
+
+    - name: Install busted
+      run: luarocks install busted
 
     - name: Run lints
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,3 @@ lint:
 
 test:
 	busted tests.lua
-

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: test
+.PHONY: ready lint test
+
+ready: lint test
+
+lint:
+	luacheck valid.lua
+	luacheck --std=min+busted tests.lua
 
 test:
 	busted tests.lua
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A library for Lua to validate various values and table structures.
   - [Validating Complex Data Types](#validating-complex-data-types)
 - [Validation Definition Functions](#validation-definition-functions)
   - [`valid.literal`](#validliteral)
+  - [`valid.boolean`](#validboolean)
   - [`valid.number`](#validnumber)
   - [`valid.string`](#validstring)
   - [`valid.table`](#validtable)
@@ -140,6 +141,29 @@ assert(is_valid) -- true
 * `opts` (optional): Table of options.
     * `icase`: Set to `true` to allow case-insensitive validation of a string literal.
     * `func`: A custom validation function to call after the literal check.
+
+
+### `valid.boolean`
+
+Validates that a value is a literal boolean either `true` or `false`.
+
+This is a shorthand for `valid.anyof {true, false}`.
+
+#### Usage
+
+```lua
+local valid = require "valid"
+
+local is_valid = valid.boolean()(true)
+assert(is_valid)  -- true
+
+local is_valid = valid.boolean()("false")
+assert(not is_valid)  -- false, not the literal boolean false
+```
+
+#### Parameters
+
+*(none)*
 
 
 ### `valid.number`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ A library for Lua to validate various values and table structures.
   - [`valid.map`](#validmap)
   - [`valid.mapof`](#validmapof)
 - [Error Handling and Invalid Propagation](#error-handling-and-invalid-propagation)
-- [Running Tests](#running-tests)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -435,6 +434,46 @@ path_or_nil:   contact email
 ## Contributing
 
 Contributions are welcome! If you have any ideas, suggestions, or bug reports, please open an issue on this GitHub repository. If you would like to contribute code, please fork the repository and submit a pull request. Make sure to follow the existing code style and include tests for any new features or bug fixes.
+
+### Code Checks and Lints
+
+This library uses [luacheck](https://github.com/mpeterv/luacheck) for code checks and lints.  It can be installed from [LuaRocks](https://luarocks.org/) with:
+
+```sh
+$ luarocks install luacheck
+```
+
+#### Running Code Checks and Lints
+
+```sh
+$ make lint
+luacheck valid.lua
+Checking valid.lua                                OK
+
+Total: 0 warnings / 0 errors in 1 file
+
+luacheck --std=min+busted tests.lua
+Checking tests.lua                                OK
+
+Total: 0 warnings / 0 errors in 1 file
+```
+
+### Tests
+
+This library uses [busted](https://github.com/lunarmodules/busted) for tests.  It can be installed from [LuaRocks](https://luarocks.org/) with:
+
+```sh
+$ luarocks install busted
+```
+
+#### Running Tests
+
+```sh
+$ make test
+busted tests.lua
+++++++++++
+10 successes / 0 failures / 0 errors / 0 pending : 0.001586 seconds
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ assert(is_valid)  -- true
 
 Validates that a value matches a specific literal.
 
+The comparison is performed using the equality operator (`==`), which means that both the value and the type must match exactly.  Note that two tables will not compare equal unless they are both references to *the same* table.
+
 #### Usage
 
 ```lua
@@ -108,7 +110,17 @@ assert(is_valid)  -- true
 
 local is_valid = valid.literal("abc")("123")
 assert(not is_valid)  -- false
+
+local is_valid = valid.literal("abc", {icase = true})("ABC")
+assert(is_valid)  -- true
 ```
+
+#### Parameters
+
+* `opts` (optional): Table of options.
+    * `icase`: Set to `true` to allow case-insensitive validation of a string literal.
+    * `func`: A custom validation function to call after the literal check.
+
 
 ### `valid.number`
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A library for Lua to validate various values and table structures.
 
 ## Installation
 
-Copy the `valid.lua` file to a directory in your `LUA_PATH`.
+Copy the [`valid.lua`](valid.lua) file to a directory in your `LUA_PATH`.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -318,10 +318,10 @@ Validates maps with specific type definitions for both keys and values.
 local valid = require "valid"
 
 -- A map where keys are strings and values are numbers within the range 1 to 10
-local valid_string_number_map = valid.mapof({
+local valid_string_number_map = valid.mapof {
     valid.string(),
     valid.number {min = 1, max = 10}
-})
+}
 
 local map_data = {
     one = 1,
@@ -382,7 +382,7 @@ The library provides detailed error information when validation fails. When `is_
 
 * `err`: Describes the type of validation error that occurred.
 * `badval`: The value that caused the validation to fail.
-* `path`: The path to the invalid key or index within the data structure.
+* `path`: The path to the invalid key or index within the table structure.
 
 These additional values can be used to pinpoint exactly where and why the validation failed.
 
@@ -415,21 +415,21 @@ local person_data = {
     }
 }
 
-local is_valid, val_or_err, badval_or_nil, path = valid_person(person_data)
+local is_valid, val_or_err, badval_or_nil, path_or_nil = valid_person(person_data)
 
 print("is_valid:", is_valid) -- false
 print("val_or_err:", val_or_err) -- "pattern"
 print("badval_or_nil:", badval_or_nil) -- invalid-email.com
 
--- path is a table like {"contact", {"email"}}
-print("path:", path[1], path[2][1]) -- "contact" "email"
+-- path_or_nil is a table like {"contact", {"email"}}
+print("path_or_nil:", path_or_nil[1], path_or_nil[2][1]) -- "contact" "email"
 ```
 
 ```
 is_valid:      false
 val_or_err:    pattern
 badval_or_nil: invalid-email.com
-path:          contact email
+path_or_nil:   contact email
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ assert(not is_valid)  -- false
 
 local is_valid = valid.literal("abc", {icase = true})("ABC")
 assert(is_valid)  -- true
+
+local price_table = {price = 1.00}
+
+local is_valid = valid.literal(price_table)({price = 1.00})
+assert(not is_valid) -- false, not the same table
+
+local is_valid = valid.literal(price_table)(price_table)
+assert(is_valid) -- true
 ```
 
 #### Parameters

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ assert(is_valid)  -- true
 
 Validates that a value matches a specific literal.
 
-The comparison is performed using the equality operator (`==`), which means that both the value and the type must match exactly.  Note that two tables will not compare equal unless they are both references to *the same* table.
+The comparison is performed using the equality operator (`==`), which means that both the value and the type must match exactly.
+
+Note: that two tables will not compare equal unless they are both references to *the same* table.
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A library for Lua to validate various values and table structures.
 ## Table of Contents
 
 - [Features](#features)
+- [Supported Lua Versions](#supported-lua-versions)
 - [Installation](#installation)
 - [Basic Usage](#basic-usage)
   - [Validating Simple Data Types](#validating-simple-data-types)
@@ -31,6 +32,15 @@ A library for Lua to validate various values and table structures.
 - Customizable validation functions.
 - Detailed error reporting with paths to invalid keys or indices.
 - Nested validations for complex table structures.
+
+## Supported Lua Versions
+
+`valid.lua` is tested with:
+
+- Lua 5.1 (including LuaJIT)
+- Lua 5.2
+- Lua 5.3
+- Lua 5.4
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -287,10 +287,10 @@ assert(not is_valid)  -- false, too long
 
 local unique_strings = valid.arrayof(valid.string(), {unique = true})
 
-local is_valid = unique_strings({"a", "b", "c"})
+local is_valid = unique_strings {"a", "b", "c"}
 assert(is_valid) -- true
 
-local is_valid = unique_strings({"a", "b", "c", "c"})
+local is_valid = unique_strings {"a", "b", "c", "c"}
 assert(not is_valid) -- false, values are not unique
 ```
 
@@ -359,7 +359,7 @@ local valid_person = valid.map {
     }
 }
 
-local valid_people_map = valid.mapof({valid.string, valid_person})
+local valid_people_map = valid.mapof {valid.string, valid_person}
 
 local people_data = {
     alice = {name = "Alice", age = 30},

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A library for Lua to validate various values and table structures.
   - [`valid.arrayof`](#validarrayof)
   - [`valid.map`](#validmap)
   - [`valid.mapof`](#validmapof)
+  - [`valid.anyof`](#validanyof)
+  - [`valid.allof`](#validallof)
   - [`valid.func`](#validfunc)
 - [Error Handling and Invalid Propagation](#error-handling-and-invalid-propagation)
 - [Contributing](#contributing)
@@ -384,6 +386,55 @@ assert(not is_valid)  -- false, "name" is required for "bob"
 * `opts` (optional): Table of options.
     * `empty`:  Set to `true` to allow empty maps.
     * `func`: A table containing two custom validation functions, one for the keys and one for the values.
+
+
+### `valid.anyof`
+
+Validates that a value satisfies at least one of the given validation functions.
+
+#### Usage
+
+```lua
+local valid = require "valid"
+
+local valid_string_or_number = valid.anyof {valid.string(), valid.number()}
+
+local is_valid = valid_string_or_number "123"
+assert(is_valid) -- true
+
+local is_valid = valid_string_or_number {name = "joe"}
+assert(not is_valid) -- false, not a string or number
+```
+
+#### Parameters
+
+* `deffuncs` (required): An array table of one or more validation functions.
+
+
+### `valid.allof`
+
+Validates that a value satisfies all of the given validation functions.
+
+#### Usage
+
+```lua
+local valid = require "valid"
+
+local valid_word_and_number = valid.allof {
+    valid.string {pattern = "%w"},
+    valid.string {pattern = "^%d+$"}
+}
+
+local is_valid = valid_word_and_number("123")
+assert(is_valid) -- true
+
+local is_valid = valid_word_and_number {name = "joe"}
+assert(not is_valid) -- false, not a string or number
+```
+
+#### Parameters
+
+* `deffuncs` (required): An array table of one or more validation functions.
 
 ### `valid.func`
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Validates that a value matches a specific literal.
 
 The comparison is performed using the equality operator (`==`), which means that both the value and the type must match exactly.
 
-Note: that two tables will not compare equal unless they are both references to *the same* table.
+Note: Two tables will not compare equal unless they are both references to *the same* table.
 
 #### Usage
 

--- a/tests.lua
+++ b/tests.lua
@@ -78,6 +78,18 @@ describe("Validation Library Tests", function()
 
     local tests = {
         {
+            description = "Case-insensitive literal",
+            definition = valid.literal("ALL CAPS", {icase = true}),
+            data = "all caps",
+            expected = {
+                is_valid = true,
+                val_or_err = "all caps",
+                badval_or_nil = nil,
+                path_or_nil = nil
+            }
+        },
+
+        {
             description = "Valid string or number",
             definition = valid.anyof {valid.string(), valid.number()},
             data = "this is a string",

--- a/tests.lua
+++ b/tests.lua
@@ -77,6 +77,59 @@ describe("Validation Library Tests", function()
     local simple_function = function() end
 
     local tests = {
+        {
+            description = "Valid string or number",
+            definition = valid.anyof {valid.string(), valid.number()},
+            data = "this is a string",
+            expected = {
+                is_valid = true,
+                val_or_err = "this is a string",
+                badval_or_nil = nil,
+                path_or_nil = nil
+            }
+        },
+
+        {
+            description = "Invalid string or number",
+            definition = valid.anyof {valid.string(), valid.number()},
+            data = false,
+            expected = {
+                is_valid = false,
+                val_or_err = "any",
+                badval_or_nil = false,
+                path_or_nil = {
+                    {"string", false},
+                    {"number", false}
+                }
+            }
+        },
+
+        {
+            description = "Valid word and number patterns",
+            definition = valid.allof {valid.string {pattern = "%w"}, valid.string {pattern = "%d"}},
+            data = "123435",
+            expected = {
+                is_valid = true,
+                val_or_err = "123435",
+                badval_or_nil = nil,
+                path_or_nil = nil
+            }
+        },
+
+        {
+            description = "Invalid word and number patterns",
+            definition = valid.allof {valid.string {pattern = "%w"}, valid.string {pattern = "^%d$"}},
+            data = "123435 not a number",
+            expected = {
+                is_valid = false,
+                val_or_err = "all",
+                badval_or_nil = "123435 not a number",
+                path_or_nil = {
+                    {"pattern", "123435 not a number"}
+                }
+            }
+        },
+
         -- Valid simple function
         {
             description = "Valid simple function",

--- a/valid.lua
+++ b/valid.lua
@@ -1,12 +1,42 @@
+--[[
+  Copyright (c) 2024, Ben Wilber
+  https://github.com/benwilber/lua-valid
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+]]
 local _M = {}
 
+-- Local reference optimizations for non-JIT'd Lua versions.
+local type = type
+local pairs = pairs
+local ipairs = ipairs
+local string_match = string.match
+local string_lower = string.lower
+local math_huge = math.huge
+
+-- The default validation function that's called
+-- when no custom function is provided.
 local function defaultfunc(val)
-    return true, val
+    -- is_valid, val_or_err, badval_or_nil, path_or_nil
+    return true, val, nil, nil
 end
 
+-- Helper that calls a custom validation function and
+-- and ensures that meaningful values are returned.
 local function callfunc(func, val)
     local is_valid, val_or_err, badval_or_nil, path_or_nil = func(val)
 
+    -- checking for nil (not false)
     if val_or_err == nil then
         if is_valid then
             val_or_err = val
@@ -23,6 +53,7 @@ local function callfunc(func, val)
     return is_valid, val_or_err, badval_or_nil, path_or_nil
 end
 
+-- Validates that a value string_matches a specific literal.
 local function literal(lit, opts)
     opts = opts or {}
     local icase = opts.icase or false
@@ -31,12 +62,14 @@ local function literal(lit, opts)
     return function(val)
         if icase and type(lit) == "string" and type(val) == "string" then
 
-            if val:lower() ~= lit:lower() then
-                return false, "literal", val
+            if string_lower(val) ~= string_lower(lit) then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
+                return false, "literal", val, nil
             end
 
         elseif val ~= lit then
-            return false, "literal", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "literal", val, nil
         end
 
         return callfunc(func, val)
@@ -44,23 +77,27 @@ local function literal(lit, opts)
 end
 _M.literal = literal
 
+-- Validates that a value is a number within an optional range.
 local function number(opts)
     opts = opts or {}
-    local min = opts.min or -math.huge
-    local max = opts.max or math.huge
+    local min = opts.min or -math_huge
+    local max = opts.max or math_huge
     local func = opts.func or defaultfunc
 
     return function(val)
         if type(val) ~= "number" then
-            return false, "number", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "number", val, nil
         end
 
         if val < min then
-            return false, "min", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "min", val, nil
         end
 
         if val > max then
-            return false, "max", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "max", val, nil
         end
 
         return callfunc(func, val)
@@ -68,40 +105,46 @@ local function number(opts)
 end
 _M.number = number
 
--- don't shadow lua's string
-local function vstring(opts)
+-- Validates that a value is a string with optional length and pattern constraints.
+-- (Don't shadow Lua's "string")
+local function _string(opts)
     opts = opts or {}
     local minlen = opts.minlen or 0
-    local maxlen = opts.maxlen or math.huge
+    local maxlen = opts.maxlen or math_huge
     local pattern = opts.pattern
     local func = opts.func or defaultfunc
 
     return function(val)
         if type(val) ~= "string" then
-            return false, "string", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "string", val, nil
         end
 
         local len = #val
 
         if len < minlen then
-            return false, "minlen", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "minlen", val, nil
         end
 
         if len > maxlen then
-            return false, "maxlen", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "maxlen", val, nil
         end
 
-        if pattern and not val:match(pattern) then
-            return false, "pattern", val
+        if pattern and not string_match(val, pattern) then
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "pattern", val, nil
         end
 
         return callfunc(func, val)
     end
 end
-_M.string = vstring
+_M.string = _string
 
--- don't shadow lua's table
-local function vtable(opts)
+-- Validates that a value is a table, with optional constraints for arrays and maps.
+-- (Don't shadow Lua's "table")
+local function _table(opts)
     opts = opts or {}
     local array = false
     local map = false
@@ -124,16 +167,19 @@ local function vtable(opts)
 
     return function(val)
         if type(val) ~= "table" then
-            return false, "table", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "table", val, nil
         end
 
         if array and #val == 0 and not empty then
-            return false, "empty", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "empty", val, nil
         end
 
         -- checking for nil (not false)
         if map and next(val) == nil and not empty then
-            return false, "empty", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "empty", val, nil
         end
 
         if required ~= "all" then
@@ -143,6 +189,7 @@ local function vtable(opts)
 
                 -- checking for nil (not false)
                 if val[key] == nil then
+                    -- is_valid, val_or_err, badval_or_nil, path_or_nil
                     return false, "required", key, {key}
                 end
             end
@@ -161,8 +208,10 @@ local function vtable(opts)
 
             v = val[key_or_idx]
 
+            -- checking for nil (not false)
             if v == nil and required == "all" then
                 -- every field is required
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, "required", key_or_idx, {key_or_idx}
             end
 
@@ -172,6 +221,7 @@ local function vtable(opts)
                 is_valid, val_or_err, badval_or_nil, path_or_nil = func_or_lit(v)
 
                 if not is_valid then
+                    -- is_valid, val_or_err, badval_or_nil, path_or_nil
                     return false, val_or_err, badval_or_nil, {key_or_idx, path_or_nil}
                 end
             end
@@ -180,10 +230,11 @@ local function vtable(opts)
         return callfunc(func, val)
     end
 end
-_M.table = vtable
+_M.table = _table
 
+-- A shorthand for valid.table with opts.array set to true.
 local function array(opts)
-    return vtable {
+    return _table {
         array = true,
         empty = opts.empty,
         required = opts.required,
@@ -193,12 +244,13 @@ local function array(opts)
 end
 _M.array = array
 
+-- Validates that a value is an array where each element string_matches a given definition.
 local function arrayof(deffunc, opts)
     opts = opts or {}
     local empty = false
     local unique = false
     local minlen = opts.minlen or 0
-    local maxlen = opts.maxlen or math.huge
+    local maxlen = opts.maxlen or math_huge
     local func = opts.func or defaultfunc
 
     if opts.empty then
@@ -219,21 +271,25 @@ local function arrayof(deffunc, opts)
 
     return function(val)
         if type(val) ~= "table" then
-            return false, "table", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "table", val, nil
         end
 
         local len = #val
 
         if len == 0 and not empty then
-            return false, "empty", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "empty", val, nil
         end
 
         if len < minlen then
-            return false, "minlen", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "minlen", val, nil
         end
 
         if len > maxlen then
-            return false, "maxlen", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "maxlen", val, nil
         end
 
         local is_valid
@@ -247,19 +303,23 @@ local function arrayof(deffunc, opts)
             is_valid, val_or_err, badval_or_nil, path_or_nil = deffunc(v)
 
             if not is_valid then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, val_or_err, badval_or_nil, {i, path_or_nil}
             end
 
             is_valid, val_or_err, badval_or_nil, path_or_nil = callfunc(func, v)
 
             if not is_valid then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, val_or_err, badval_or_nil, {i, path_or_nil}
             end
 
             if unique then
                 prev_i = set[v]
 
+                -- checking for nil (not false)
                 if prev_i ~= nil then
+                    -- is_valid, val_or_err, badval_or_nil, path_or_nil
                     return false, "unique", v, {prev_i, i}
                 else
                     set[v] = i
@@ -267,13 +327,15 @@ local function arrayof(deffunc, opts)
             end
         end
 
-        return true, val
+        -- is_valid, val_or_err, badval_or_nil, path_or_nil
+        return true, val, nil, nil
     end
 end
 _M.arrayof = arrayof
 
+-- A shorthand for valid.table with opts.map set to true.
 local function map(opts)
-    return vtable {
+    return _table {
         map = true,
         empty = opts.empty,
         required = opts.required,
@@ -283,6 +345,7 @@ local function map(opts)
 end
 _M.map = map
 
+-- Validates maps with specific type definitions for both keys and values.
 local function mapof(deffuncs, opts)
     opts = opts or {}
     local empty = false
@@ -302,12 +365,14 @@ local function mapof(deffuncs, opts)
 
     return function(val)
         if type(val) ~= "table" then
-            return false, "table", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "table", val, nil
         end
 
         -- checking for nil (not false)
         if next(val) == nil and not empty then
-            return false, "empty", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "empty", val, nil
         end
 
         local is_valid
@@ -319,44 +384,53 @@ local function mapof(deffuncs, opts)
             is_valid, val_or_err, badval_or_nil, path_or_nil = keydeffunc(k)
 
             if not is_valid then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, val_or_err, badval_or_nil, {k, path_or_nil}
             end
 
             is_valid, val_or_err, badval_or_nil, path_or_nil = keyfunc(k)
 
             if not is_valid then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, val_or_err, badval_or_nil, {k, path_or_nil}
             end
 
             is_valid, val_or_err, badval_or_nil, path_or_nil = valdeffunc(v)
 
             if not is_valid then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, val_or_err, badval_or_nil, {k, v, path_or_nil}
             end
 
             is_valid, val_or_err, badval_or_nil, path_or_nil = valfunc(v)
 
             if not is_valid then
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
                 return false, val_or_err, badval_or_nil, {k, v, path_or_nil}
             end
         end
 
-        return true, val
+        -- is_valid, val_or_err, badval_or_nil, path_or_nil
+        return true, val, nil, nil
     end
 end
 _M.mapof = mapof
 
+-- Validates that a value is a function.
 local function func()
     return function(val)
         if type(val) ~= "function" then
-            return false, "func", val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return false, "func", val, nil
         end
 
-        return true, val
+        -- is_valid, val_or_err, badval_or_nil, path_or_nil
+        return true, val, nil, nil
     end
 end
 _M.func = func
 
+-- Validates that a value satisfies at least one of the given validation functions.
 local function anyof(deffuncs)
     return function(val)
         local is_valid
@@ -369,17 +443,20 @@ local function anyof(deffuncs)
             is_valid, val_or_err, badval_or_nil, path_or_nil = deffunc(val)
 
             if is_valid then
-                return true, val
+                -- is_valid, val_or_err, badval_or_nil, path_or_nil
+                return true, val, nil, nil
             else
                 errtabs[#errtabs + 1] = {val_or_err, badval_or_nil, path_or_nil}
             end
         end
 
+        -- is_valid, val_or_err, badval_or_nil, path_or_nil
         return false, "any", val, errtabs
     end
 end
 _M.anyof = anyof
 
+-- Validates that a value satisfies all of the given validation functions.
 local function allof(deffuncs)
     return function(val)
         local is_valid
@@ -397,8 +474,10 @@ local function allof(deffuncs)
         end
 
         if #errtabs == 0 then
-            return true, val
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
+            return true, val, nil, nil
         else
+            -- is_valid, val_or_err, badval_or_nil, path_or_nil
             return false, "all", val, errtabs
         end
     end

--- a/valid.lua
+++ b/valid.lua
@@ -1,7 +1,7 @@
 local _M = {}
 
 local function defaultfunc(val)
-    return true, val, nil
+    return true, val
 end
 
 local function callfunc(func, val)
@@ -103,15 +103,15 @@ local function vtable(opts)
     local func = opts.func or defaultfunc
     local tabledef = opts.table
 
-    if opts.array == true then
+    if opts.array then
         array = true
     end
 
-    if opts.map == true then
+    if opts.map then
         map = true
     end
 
-    if opts.empty == true then
+    if opts.empty then
         empty = true
     end
 
@@ -131,6 +131,8 @@ local function vtable(opts)
 
         -- required fields
         for _, key in ipairs(required) do
+
+            -- checking for nil (not false)
             if val[key] == nil then
                 return false, "required", key, {key}
             end
@@ -141,17 +143,18 @@ local function vtable(opts)
         local badval_or_nil
         local path_or_nil
 
-        for key, func_or_lit in pairs(tabledef) do
+        for key_or_idx, func_or_lit in pairs(tabledef) do
             if type(func_or_lit) ~= "function" then
                 func_or_lit = literal(func_or_lit)
             end
 
             -- we already validated the required fields
-            if val[key] ~= nil then
-                is_valid, val_or_err, badval_or_nil, path_or_nil = func_or_lit(val[key])
+            -- checking for nil (not false)
+            if val[key_or_idx] ~= nil then
+                is_valid, val_or_err, badval_or_nil, path_or_nil = func_or_lit(val[key_or_idx])
 
                 if not is_valid then
-                    return false, val_or_err, badval_or_nil, {key, path_or_nil}
+                    return false, val_or_err, badval_or_nil, {key_or_idx, path_or_nil}
                 end
             end
         end

--- a/valid.lua
+++ b/valid.lua
@@ -7,14 +7,14 @@ end
 local function callfunc(func, val)
     local is_valid, val_or_err, badval_or_nil = func(val)
 
-    if not val_or_err then
+    if val_or_err == nil then
         if is_valid then
             val_or_err = val
             badval_or_nil = nil
         else
             val_or_err = "func"
 
-            if not badval_or_nil then
+            if badval_or_nil == nil then
                 badval_or_nil = val
             end
         end
@@ -139,7 +139,7 @@ local function vtable(opts)
         local is_valid
         local val_or_err
         local badval_or_nil
-        local sub_path
+        local path_or_nil
 
         for key, func_or_lit in pairs(tabledef) do
             if type(func_or_lit) ~= "function" then
@@ -148,10 +148,10 @@ local function vtable(opts)
 
             -- we already validated the required fields
             if val[key] ~= nil then
-                is_valid, val_or_err, badval_or_nil, sub_path = func_or_lit(val[key])
+                is_valid, val_or_err, badval_or_nil, path_or_nil = func_or_lit(val[key])
 
                 if not is_valid then
-                    return false, val_or_err, badval_or_nil, {key, sub_path}
+                    return false, val_or_err, badval_or_nil, {key, path_or_nil}
                 end
             end
         end
@@ -179,7 +179,7 @@ local function arrayof(deffunc, opts)
     local maxlen = opts.maxlen or math.huge
     local func = opts.func or defaultfunc
 
-    if opts.empty == true then
+    if opts.empty then
         empty = true
 
         -- minlen doesnt matter if empty = true
@@ -213,23 +213,23 @@ local function arrayof(deffunc, opts)
         local is_valid
         local val_or_err
         local badval_or_nil
-        local sub_path
+        local path_or_nil
 
         for i, v in ipairs(val) do
-            is_valid, val_or_err, badval_or_nil, sub_path = deffunc(v)
+            is_valid, val_or_err, badval_or_nil, path_or_nil = deffunc(v)
 
             if not is_valid then
-                return false, val_or_err, badval_or_nil, {i, sub_path}
+                return false, val_or_err, badval_or_nil, {i, path_or_nil}
             end
 
-            is_valid, val_or_err, badval_or_nil, sub_path = callfunc(func, v)
+            is_valid, val_or_err, badval_or_nil, path_or_nil = callfunc(func, v)
 
             if not is_valid then
-                return false, val_or_err, badval_or_nil, {i, sub_path}
+                return false, val_or_err, badval_or_nil, {i, path_or_nil}
             end
         end
 
-        return true, val, nil
+        return true, val
     end
 end
 _M.arrayof = arrayof
@@ -248,8 +248,8 @@ _M.map = map
 local function mapof(deffuncs, opts)
     opts = opts or {}
     local empty = false
-    local keydeffunc = deffuncs[1]
-    local valdeffunc = deffuncs[2]
+    local keydeffunc = deffuncs[1] or defaultfunc
+    local valdeffunc = deffuncs[2] or defaultfunc
     local keyfunc = defaultfunc
     local valfunc = defaultfunc
 
@@ -258,7 +258,7 @@ local function mapof(deffuncs, opts)
         valfunc = opts.func[2] or defaultfunc
     end
 
-    if opts.empty == true then
+    if opts.empty then
         empty = true
     end
 
@@ -267,6 +267,7 @@ local function mapof(deffuncs, opts)
             return false, "table", val
         end
 
+        -- checking for nil (not false)
         if next(val) == nil and not empty then
             return false, "empty", val
         end
@@ -274,31 +275,31 @@ local function mapof(deffuncs, opts)
         local is_valid
         local val_or_err
         local badval_or_nil
-        local sub_path
+        local path_or_nil
 
         for k, v in pairs(val) do
-            is_valid, val_or_err, badval_or_nil, sub_path = keydeffunc(k)
+            is_valid, val_or_err, badval_or_nil, path_or_nil = keydeffunc(k)
 
             if not is_valid then
-                return false, val_or_err, badval_or_nil, {k, sub_path}
+                return false, val_or_err, badval_or_nil, {k, path_or_nil}
             end
 
-            is_valid, val_or_err, badval_or_nil, sub_path = keyfunc(k)
+            is_valid, val_or_err, badval_or_nil, path_or_nil = keyfunc(k)
 
             if not is_valid then
-                return false, val_or_err, badval_or_nil, {k, sub_path}
+                return false, val_or_err, badval_or_nil, {k, path_or_nil}
             end
 
-            is_valid, val_or_err, badval_or_nil, sub_path = valdeffunc(v)
+            is_valid, val_or_err, badval_or_nil, path_or_nil = valdeffunc(v)
 
             if not is_valid then
-                return false, val_or_err, badval_or_nil, {k, v, sub_path}
+                return false, val_or_err, badval_or_nil, {k, v, path_or_nil}
             end
 
-            is_valid, val_or_err, badval_or_nil, sub_path = valfunc(v)
+            is_valid, val_or_err, badval_or_nil, path_or_nil = valfunc(v)
 
             if not is_valid then
-                return false, val_or_err, badval_or_nil, {k, v, sub_path}
+                return false, val_or_err, badval_or_nil, {k, v, path_or_nil}
             end
         end
 

--- a/valid.lua
+++ b/valid.lua
@@ -350,4 +350,52 @@ local function func()
 end
 _M.func = func
 
+local function anyof(deffuncs)
+    return function(val)
+        local is_valid
+        local val_or_err
+        local badval_or_nil
+        local path_or_nil
+        local errtabs = {}
+
+        for _, deffunc in ipairs(deffuncs) do
+            is_valid, val_or_err, badval_or_nil, path_or_nil = deffunc(val)
+
+            if is_valid then
+                return true, val
+            else
+                errtabs[#errtabs + 1] = {val_or_err, badval_or_nil, path_or_nil}
+            end
+        end
+
+        return false, "any", val, errtabs
+    end
+end
+_M.anyof = anyof
+
+local function allof(deffuncs)
+    return function(val)
+        local is_valid
+        local val_or_err
+        local badval_or_nil
+        local path_or_nil
+        local errtabs = {}
+
+        for _, deffunc in ipairs(deffuncs) do
+            is_valid, val_or_err, badval_or_nil, path_or_nil = deffunc(val)
+
+            if not is_valid then
+                errtabs[#errtabs + 1] = {val_or_err, badval_or_nil, path_or_nil}
+            end
+        end
+
+        if #errtabs == 0 then
+            return true, val
+        else
+            return false, "all", val, errtabs
+        end
+    end
+end
+_M.allof = allof
+
 return _M

--- a/valid.lua
+++ b/valid.lua
@@ -5,7 +5,7 @@ local function defaultfunc(val)
 end
 
 local function callfunc(func, val)
-    local is_valid, val_or_err, badval_or_nil = func(val)
+    local is_valid, val_or_err, badval_or_nil, path_or_nil = func(val)
 
     if val_or_err == nil then
         if is_valid then
@@ -20,7 +20,7 @@ local function callfunc(func, val)
         end
     end
 
-    return is_valid, val_or_err, badval_or_nil
+    return is_valid, val_or_err, badval_or_nil, path_or_nil
 end
 
 local function literal(lit, opts)

--- a/valid.lua
+++ b/valid.lua
@@ -25,10 +25,17 @@ end
 
 local function literal(lit, opts)
     opts = opts or {}
+    local icase = opts.icase or false
     local func = opts.func or defaultfunc
 
     return function(val)
-        if val ~= lit then
+        if icase and type(lit) == "string" and type(val) == "string" then
+
+            if val:lower() ~= lit:lower() then
+                return false, "literal", val
+            end
+
+        elseif val ~= lit then
             return false, "literal", val
         end
 


### PR DESCRIPTION
* Added a `valid.boolean()` function for checking literal boolean `true` or `false`
* Allow `valid.anyof()` and `valid.allof()` to accept literals in addition to function defs
* Test against OpenResty's LuaJIT distribution since LuaJIT.org doesn't publish release tarballs anymore.
  * See https://github.com/leafo/gh-actions-lua/issues/49
* Take local refs to oft-used globals and built-ins as an optimization for non-JIT'd Lua versions
* Add Apache 2.0 license preamble to `valid.lua`
* Add comments everywhere that returns a value indicating explicitly what it is returning and what the caller can expect